### PR TITLE
Update h5_to_pdb.py for bug fix

### DIFF
--- a/src/data/processing/h5_to_pdb.py
+++ b/src/data/processing/h5_to_pdb.py
@@ -69,7 +69,7 @@ def update_residue_indices(residue_number, i, type_string, atoms_type, atoms_res
     If the atom sequence has O-N icnrease the residueNumber
     """
     if i < len(atoms_type)-1:
-        if type_string == 'O' and typeMap[atoms_type[i+1]] == 'N' or residue_Map[atoms_residue[i+1]]=='MOL':
+        if type_string[0] == 'O' and typeMap[atoms_type[i+1]][0] == 'N' or residue_Map[atoms_residue[i+1]]=='MOL':
             # GLN has a O N sequence within the AA
             if not ((residue_name == 'GLN' and residue_atom_index==12) or (residue_name == 'ASN' and residue_atom_index==9)):
                 residue_number +=1


### PR DESCRIPTION
This bug will cause some residue index can't be updated correctly. For example in 1A2C, a ILE after ARG residue number can't be increased correctly.