### PR TITLE
Correct h5 to PDB residue index error

### DIFF
--- a/src/data/processing/h5_to_pdb.py
+++ b/src/data/processing/h5_to_pdb.py
@@ -70,7 +70,7 @@ def update_residue_indices(residue_number, i, type_string, atoms_type, atoms_res
     """
     if i < len(atoms_type)-1:
         if type_string[0] == 'O' and typeMap[atoms_type[i+1]][0] == 'N' or residue_Map[atoms_residue[i+1]]=='MOL':
-            # GLN has a O N sequence within the AA
+            # GLN and ASN have a O-N sequence within the AA. See nameMap (atoms_name_map_for_pdb.pickle)
             if not ((residue_name == 'GLN' and residue_atom_index in [12, 14]) or (residue_name == 'ASN' and residue_atom_index in [9, 11])):
                 residue_number +=1
                 residue_atom_index = 0

--- a/src/data/processing/h5_to_pdb.py
+++ b/src/data/processing/h5_to_pdb.py
@@ -71,7 +71,7 @@ def update_residue_indices(residue_number, i, type_string, atoms_type, atoms_res
     if i < len(atoms_type)-1:
         if type_string[0] == 'O' and typeMap[atoms_type[i+1]][0] == 'N' or residue_Map[atoms_residue[i+1]]=='MOL':
             # GLN has a O N sequence within the AA
-            if not ((residue_name == 'GLN' and residue_atom_index==12) or (residue_name == 'ASN' and residue_atom_index==9)):
+            if not ((residue_name == 'GLN' and residue_atom_index in [12, 14]) or (residue_name == 'ASN' and residue_atom_index in [9, 11])):
                 residue_number +=1
                 residue_atom_index = 0
     return residue_number, residue_atom_index


### PR DESCRIPTION
Fixes #8. 

As mentioned there, the h5_to_pdb.py incorrectly splits some GLN and ASN residues when converting to pdb format. While the script accounts for this by ignoring index 12 and 9 in `GLN` and `ASN` respectively it misses the fact that the O-N pair can be in another location within the AA. From `atoms_name_map_for_pdb.pickle` we can see that this can also occur at  indices 14 (`GLN`) and 11 (`ASN`).

This is a simple fix but I think it would be a good idea to look into cleaning up and refactoring the format conversion code to make it easier to understand.